### PR TITLE
[25] Move Hubspot Script import to React Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,23 @@ $ npm install --save @aaronhayes/react-use-hubspot-form
 $ yarn add @aaronhayes/react-use-hubspot-form
 ```
 
+## Getting Started
+
+Wrap your application with `HubspotProvider`. This will add [Hubspot script](https://js.hsforms.net/forms/v2.js) to the head of your document.
+
+```TypeScript
+import React from 'react';
+
+import { HubspotProvider } from '@aaronhayes/react-use-hubspot-form';
+
+const MyApp = () => (
+    <HubspotProvider>
+        <MyPage />
+    </HubspotProvider>
+)
+
+```
+
 ## Usage
 
 ```TypeScript

--- a/src/HubspotProvider.tsx
+++ b/src/HubspotProvider.tsx
@@ -1,0 +1,27 @@
+import React, { createContext, useContext } from 'react';
+import useScript from './useScript';
+
+export interface HubspotContextProps {
+  loaded: boolean; // Is Hubspot script loaded
+  error: boolean; // Is Hubspot failed to loaded
+}
+
+export const HubspotContext = createContext<HubspotContextProps>({
+  loaded: false,
+  error: false
+});
+
+export const useHubspotContext = () => useContext(HubspotContext);
+
+const HubspotProvider = ({ children }) => {
+  // Attach hubspot script to the head of the document
+  const [loaded, error] = useScript('https://js.hsforms.net/forms/v2.js');
+
+  return (
+    <HubspotContext.Provider value={{ loaded, error }}>
+      {children}
+    </HubspotContext.Provider>
+  );
+};
+
+export default HubspotProvider;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 import { useEffect, useState } from 'react';
 import { HubSpotFormLocale } from './hubspot-form-locale.enum';
-import useScript from './useScript';
+import HubspotProvider, {
+  useHubspotContext,
+  HubspotContextProps
+} from './HubspotProvider';
 
 interface WindowWithHubspot extends Window {
   // TODO improve typings
@@ -102,7 +105,7 @@ interface UseHubSpotFormProps {
 export const useHubspotForm = (
   props: Readonly<UseHubSpotFormProps>
 ): UseHubSpotFormResponse => {
-  const [loaded, error] = useScript('https://js.hsforms.net/forms/v2.js');
+  const { loaded, error } = useHubspotContext();
   const [formCreated, setFormCreated] = useState(false);
 
   useEffect(() => {
@@ -117,3 +120,5 @@ export const useHubspotForm = (
 
   return { loaded, formCreated, error };
 };
+
+export { HubspotProvider, useHubspotContext, HubspotContextProps };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "inlineSourceMap": true,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+    "jsx": "react",
 
     "strict": false /* Enable all strict type-checking options. */,
 
@@ -40,7 +41,7 @@
     "types": ["node"],
     "typeRoots": ["node_modules/@types", "src/types"]
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["node_modules/**"],
   "compileOnSave": false
 }


### PR DESCRIPTION
Refs #25

## ⚠This PR contains breaking change

You need to wrap your application with `HubspotProvider` for context to work.
I recommend publishing it as a new major version.