### PR TITLE
feat: allow for synchronous loading and appending to head

### DIFF
--- a/src/HubspotProvider.tsx
+++ b/src/HubspotProvider.tsx
@@ -13,9 +13,23 @@ export const HubspotContext = createContext<HubspotContextProps>({
 
 export const useHubspotContext = () => useContext(HubspotContext);
 
-const HubspotProvider = ({ children }) => {
-  // Attach hubspot script to the head of the document
-  const [loaded, error] = useScript('https://js.hsforms.net/forms/v2.js');
+interface HubspotProviderProps {
+  readonly async?: boolean;
+  readonly addToHead?: boolean;
+  readonly children: React.ReactNode;
+}
+
+const HubspotProvider = ({
+  async,
+  addToHead,
+  children
+}: HubspotProviderProps) => {
+  // Attach hubspot script to the document
+  const [loaded, error] = useScript(
+    'https://js.hsforms.net/forms/v2.js',
+    async,
+    addToHead
+  );
 
   return (
     <HubspotContext.Provider value={{ loaded, error }}>

--- a/src/useScript.ts
+++ b/src/useScript.ts
@@ -3,7 +3,11 @@ import { useEffect, useState } from 'react';
 // Hook
 const cachedScripts: string[] = [];
 
-function useScript(src: string): boolean[] {
+function useScript(
+  src: string,
+  async: boolean = true,
+  addToHead: boolean = false
+): boolean[] {
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState(false);
 
@@ -19,7 +23,7 @@ function useScript(src: string): boolean[] {
       // Create script
       const script = document.createElement('script');
       script.src = src;
-      script.async = true;
+      script.async = async;
 
       // Script event listener callbacks for load and error
       const onScriptLoad = () => {
@@ -42,8 +46,10 @@ function useScript(src: string): boolean[] {
       script.addEventListener('load', onScriptLoad);
       script.addEventListener('error', onScriptError);
 
-      // Add script to document body
-      document.body.appendChild(script);
+      // Add script to document head if required, otherwise to the body
+      addToHead
+        ? document.head.appendChild(script)
+        : document.body.appendChild(script);
 
       // Remove event listeners on cleanup
       return () => {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
Currently, the only way to load the script is asynchronously and appending the script to the document body.
Linked issue; https://github.com/aaronhayes/react-use-hubspot-form/issues/29

- **What is the new behavior (if this is a feature change)?**
Optionally load the script synchronously and optionally append the script to the document head. By default, it will still load asynchronously and appending to the document body.

* **Other information**:
