### PR TITLE
fix: HubSpotFormLocale type not exported for use in locale prop

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -121,4 +121,9 @@ export const useHubspotForm = (
   return { loaded, formCreated, error };
 };
 
-export { HubspotProvider, useHubspotContext, HubspotContextProps };
+export {
+  HubspotProvider,
+  useHubspotContext,
+  HubspotContextProps,
+  HubSpotFormLocale
+};


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
Unable to pass in `locale` prop because HubSpotFormLocale is not exported

- **What is the new behavior (if this is a feature change)?**
`locale` prop can be pass using the HubSpotFormLocale enum type (e.g., `locale: HubSpotFormLocale.GERMAN`)

* **Other information**:
Thanks for writing and maintaining this project!